### PR TITLE
Make it runable with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:alpine
+
+WORKDIR /app
+
+RUN apk update && apk add --no-cache bash
+
+RUN pip install \
+    "discord.py>=2.3.2" \
+    litellm \
+    python-dotenv
+
+COPY . /app
+RUN cp /app/.env.example /app/.env
+RUN chown -R 1000:1000 /app
+USER 1000
+
+CMD ["bash", "run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+ENV_FILE=".env"
+while IFS='=' read -r name value ; do
+    if [[ "$name" =~ ^(PATH|PWD|SHLVL|_) ]]; then
+        continue
+    fi
+
+    sed -i "/^$name=/d" "$ENV_FILE"
+    echo "$name=$value" >> "$ENV_FILE"
+done < <(env)
+
+python llmcord.py


### PR DESCRIPTION
Add Dockerfile and Entrypoint script to get it running as a Docker image. Allows to specify the configuration parameter as Env parameter. As an example:

docker run -e DISCORD_BOT_TOKEN=... -e DISCORD_CLIENT_ID=...