### PR TITLE
fix NoneType found in text

### DIFF
--- a/llmcord.py
+++ b/llmcord.py
@@ -106,8 +106,8 @@ async def on_message(new_msg):
 
                 text = "\n".join(
                     ([curr_msg.content] if curr_msg.content else [])
-                    + [embed.description for embed in curr_msg.embeds]
-                    + [requests.get(att.url).text for att in good_attachments["text"]]
+                    + [embed.description for embed in curr_msg.embeds if embed.description is not None]
+                    + [requests.get(att.url).text for att in good_attachments["text"] if requests.get(att.url).text is not None]
                 )
                 if curr_msg.content.startswith(bot.user.mention):
                     text = text.replace(bot.user.mention, "", 1).lstrip()


### PR DESCRIPTION
When sending message with latest python script, it throwed an error.

```
TypeError: sequence item 1: expected str instance, NoneType found
```